### PR TITLE
Fix GitHub Pages documentation publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,8 @@ jobs:
   # Documentation build
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The docs job needs explicit write permissions to deploy to GitHub Pages. This adds the 'contents: write' permission to allow the peaceiris/actions-gh-pages action to push to the gh-pages branch.