### PR TITLE
Fix release workflow errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,40 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-bin-cross-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bin-cross-
+            ${{ runner.os }}-cargo-bin-
+
+      - name: Cache cargo build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Setup Docker for cross
+        run: |
+          docker --version
+          docker info
+
       - name: Install cross
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross
+          if ! command -v cross &> /dev/null; then
+            echo "Installing cross..."
+            cargo install cross
+          else
+            echo "cross is already installed"
+            cross --version
+          fi
 
       - name: Install zip utility
         run: |
@@ -36,6 +67,7 @@ jobs:
 
       - name: Build all multi-platform FMUs
         run: |
+          set -x  # Enable verbose output for debugging
           ./scripts/build-all-multiplatform-fmus.sh
 
       - name: List built FMUs


### PR DESCRIPTION
- Install cross from stable crates.io instead of git for reliability
- Add caching for cargo binaries and build artifacts to speed up builds
- Add Docker verification step to ensure cross can run properly
- Add conditional check to skip cross installation if already cached
- Enable verbose output (set -x) for better debugging
- These changes should resolve the workflow failure and improve build times