### PR TITLE
feat: upgrade fmi-export to v0.2 and re-enable FMU validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "fmi"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e6bf39dedcfda6843049b18a8e0cdcbb6a30dc785027c61060f4601dc91507"
+checksum = "86c41a8885b1cea2cb97bb2b63ce575877f2b2c3851d6e7b71d603b57c7a8730"
 dependencies = [
  "built",
  "document-features",
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "fmi-export"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6aa827e540df48e6aa0dc719cd78affe0a2f978c96634b828c6f0efb73e8a30"
+checksum = "01af7b26a84cfafee3c2b15c777b204a722f4c59470fdf42faf8df92d1ff1aa9"
 dependencies = [
  "chrono",
  "document-features",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "fmi-export-derive"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e0db0636c9115a06aa06b756ffd7025d1b78156ec633856c6230d6d7729f05"
+checksum = "1d10386b862afa7130e91319daed68a65775c00b6ab9b16afa1d4ee765b1b93f"
 dependencies = [
  "attribute-derive",
  "chrono",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "fmi-schema"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332fb9c777fb96f49e32408c11a49eca71e1e19d821b09b21b547fc68c42015"
+checksum = "43ead17b6997a1934d92159150709e41ba3afebfd23964438c2953488d09d476"
 dependencies = [
  "chrono",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ check-cfg = ['cfg(coverage_nightly)']
 
 [workspace.dependencies]
 # FMI export dependencies - migrated to fmi-export from rust-fmi
-fmi-export = "0.1"
-fmi = { version = "0.6", default-features = false, features = ["fmi3"] }
+fmi-export = "0.2"
+fmi = { version = "0.7", default-features = false, features = ["fmi3"] }
 
 # ADML shared crates
 adml-solver = { path = "crates/adml-solver" }

--- a/models/mechanical/simple-pendulum/src/lib.rs
+++ b/models/mechanical/simple-pendulum/src/lib.rs
@@ -79,15 +79,15 @@ pub struct SimplePendulum {
 
     // === Derived Outputs (calculated after integration) ===
     /// Total mechanical energy [J]
-    #[variable(causality = Output, start = 0.0, initial = Calculated)]
+    #[variable(causality = Output, initial = Calculated)]
     pub energy: f64,
 
     /// Kinetic energy [J]
-    #[variable(causality = Output, start = 0.0, initial = Calculated)]
+    #[variable(causality = Output, initial = Calculated)]
     pub KE: f64,
 
     /// Potential energy [J], reference at lowest point
-    #[variable(causality = Output, start = 0.0, initial = Calculated)]
+    #[variable(causality = Output, initial = Calculated)]
     pub PE: f64,
 
     /// Derivative of theta

--- a/models/thermal/rc-thermal-single-zone/src/lib.rs
+++ b/models/thermal/rc-thermal-single-zone/src/lib.rs
@@ -65,11 +65,11 @@ pub struct RcThermalSingleZone {
     pub T_indoor: f64,
 
     /// Heat flow through envelope [W] (positive = heat loss)
-    #[variable(causality = Output, start = 0.0, initial = Calculated)]
+    #[variable(causality = Output, initial = Calculated)]
     pub Q_envelope: f64,
 
     /// Net heat flow into zone [W]
-    #[variable(causality = Output, start = 0.0, initial = Calculated)]
+    #[variable(causality = Output, initial = Calculated)]
     pub Q_net: f64,
 
     /// Derivative of indoor temperature

--- a/scripts/generate_fmu_figures.py
+++ b/scripts/generate_fmu_figures.py
@@ -52,7 +52,7 @@ def load_plot_config(model_dir: Path) -> Optional[Dict[str, Any]]:
 
 def get_fmu_outputs(fmu_path: Path) -> List[str]:
     """Get list of output variable names from FMU model description."""
-    model_desc = read_model_description(str(fmu_path), validate=False)
+    model_desc = read_model_description(str(fmu_path), validate=True)
     outputs = []
     for var in model_desc.modelVariables:
         if var.causality == 'output':
@@ -80,7 +80,7 @@ def create_generic_plot(fmu_path: Path, model_name: str, output_dir: Path,
             stop_time=5.0,
             step_size=0.01,
             output_interval=0.01,
-            validate=False,
+            validate=True,
         )
 
         # Create single plot with all outputs
@@ -220,7 +220,7 @@ def create_configured_plot(fmu_path: Path, model_name: str, config: Dict[str, An
             stop_time=stop_time,
             step_size=step_size,
             output_interval=output_interval,
-            validate=False,
+            validate=True,
             start_values=start_values if start_values else None
         )
 

--- a/testing/fmu-integration-tests/fmu_test_utils.py
+++ b/testing/fmu-integration-tests/fmu_test_utils.py
@@ -73,7 +73,7 @@ def simulate_fmu(
         )
 
     # Read model description to get variable names
-    model_description = read_model_description(fmu_path, validate=False)
+    model_description = read_model_description(fmu_path, validate=True)
 
     # Prepare start values from parameters
     start_values = parameters if parameters else {}
@@ -100,7 +100,7 @@ def simulate_fmu(
         step_size=actual_step_size,
         output_interval=actual_step_size,  # Record at every step for accuracy
         start_values=start_values,
-        validate=False,  # Disabled: fmi-export v0.1.1 generates non-compliant ModelStructure ordering
+        validate=True,
         fmi_call_logger=None,  # Can enable for debugging
     )
 
@@ -221,7 +221,7 @@ def validate_fmu_structure(fmu_path: Path) -> Dict[str, any]:
         raise ImportError("FMPy is required. Install with: pip install fmpy")
 
     # Extract FMU to temporary directory for inspection
-    model_description = read_model_description(fmu_path, validate=False)
+    model_description = read_model_description(fmu_path, validate=True)
 
     metadata = {
         'fmi_version': model_description.fmiVersion,


### PR DESCRIPTION
fmi-export v0.2.0 fixes the non-compliant ModelStructure ordering
that required disabling FMPy validation. This upgrades fmi-export
from v0.1 to v0.2 (and fmi from v0.6 to v0.7), removes invalid
start values from calculated output variables in SimplePendulum
and RcThermalSingleZone, and re-enables validate=True in all
FMPy calls across test utilities and figure generation scripts.

https://claude.ai/code/session_01J9CusgoDnLvdiiebVMmKE8